### PR TITLE
Add Popout Component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,25 +1,15 @@
-import logo from './logo.svg';
-import './App.css';
+import ExpandedFooter from './components/footer/ExpandedFooter';
+import Footer from './components/footer/Footer';
+import GetInTouch from './components/get-in-touch/GetInTouch';
+import PopOut from './components/popout/PopOut';
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+export default function App() {
+    return (
+        <div className='flex flex-col'>
+            <PopOut />
+            <GetInTouch />
+            <ExpandedFooter />
+            <Footer />
+        </div>
+    );
 }
-
-export default App;

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,46 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import ExpandedFooter from './components/footer/ExpandedFooter';
+import Footer from './components/footer/Footer';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Mock the child components
+jest.mock('./components/footer/ExpandedFooter', () => {
+    return function MockExpandedFooter() {
+        return <div data-testid='expanded-footer'>Mocked Expanded Footer</div>;
+    };
+});
+
+jest.mock('./components/footer/Footer', () => {
+    return function MockFooter() {
+        return <div data-testid='footer'>Mocked Footer</div>;
+    };
+});
+
+describe('App Component', () => {
+    it('renders without crashing', () => {
+        render(<App />);
+    });
+
+    it('renders with correct layout structure', () => {
+        render(<App />);
+        const container = screen.getByTestId('expanded-footer').parentElement;
+        expect(container).toHaveClass('flex flex-col');
+    });
+
+    it('renders ExpandedFooter component', () => {
+        render(<App />);
+        expect(screen.getByTestId('expanded-footer')).toBeInTheDocument();
+    });
+
+    it('renders Footer component', () => {
+        render(<App />);
+        expect(screen.getByTestId('footer')).toBeInTheDocument();
+    });
+
+    it('renders components in correct order', () => {
+        render(<App />);
+        const elements = screen.getAllByTestId(/footer/);
+        expect(elements[0]).toHaveAttribute('data-testid', 'expanded-footer');
+        expect(elements[1]).toHaveAttribute('data-testid', 'footer');
+    });
 });

--- a/frontend/src/components/popout/PopOut.jsx
+++ b/frontend/src/components/popout/PopOut.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function PopOut() {
+    return (
+        <div className='overflow-hidden w-[1110px] h-[425px] relative mx-auto my-0'>
+            <div className='w-[1110px] h-[425px] bg-gradient-to-r from-[#FF9898] to-[#8054FF] bg-cover bg-no-repeat rounded-[40px] absolute top-0 left-0' />
+            <div className='w-[554px] h-[369px] bg-[url(https://cdn.builder.io/api/v1/image/assets/0a7524ba7fb14db381bea79b3ad860c0/154e310cc2380c51edcfff18336c0d737384a4c87c4a74aac3dbd1741a5d5fdc?apiKey=0a7524ba7fb14db381bea79b3ad860c0&)] bg-cover bg-no-repeat absolute top-[37px] left-[556px] overflow-hidden z-[6]' />
+            <span className="flex w-[141px] h-[32px] justify-center items-start text-lg font-normal leading-[32px] text-[#fff] absolute top-[100px] left-[97px] text-center whitespace-nowrap z-[3]">
+                Love our Tool?
+            </span>
+            <span className="flex w-[499px] h-[130px] justify-start items-start text-[48px] font-semibold leading-[65px] text-[#fff] absolute top-[143px] left-[97px] text-left z-[2]">
+                Create your First Checkpoint Today
+            </span>
+            <button className='flex w-[247px] h-[44px] pt-[12px] pr-[28px] pb-[12px] pl-[28px] gap-[10px] items-start flex-nowrap bg-[#000] rounded-[5px] border-none absolute top-[309px] left-[97px] z-[4] pointer outline-none'>
+                <span className="h-[20px] shrink-0 basis-auto text-[14px] font-normal leading-[20px] text-[#fff] relative text-left whitespace-nowrap z-[5]">
+                    Check it out on PrairieLearn
+                </span>
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,31 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+    --default-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC',
+        'Hiragino Sans GB', 'Microsoft Yahei UI', 'Microsoft Yahei',
+        'Source Han Sans CN', sans-serif;
+}
+
+html,
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+        'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+        'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+        monospace;
 }


### PR DESCRIPTION
This pull request includes significant updates to the `frontend/src` directory, focusing on enhancing the `App` component and its associated tests, adding new components, and updating styles. The most important changes include the restructuring of the `App` component, the introduction of the `PopOut` component, and the addition of Tailwind CSS for styling.

### Restructuring and enhancement of the `App` component:

* [`frontend/src/App.js`](diffhunk://#diff-4e185b456927ee5c9781afdfbd5054b8cfb34c5b099a169c2bab8c822931625cL1-L25): Refactored the `App` component to use new child components (`PopOut`, `GetInTouch`, `ExpandedFooter`, and `Footer`) and removed the default content. The `App` component is now exported directly.

### Updates to tests:

* [`frontend/src/App.test.js`](diffhunk://#diff-3c5fe99173ea5f0f99095e97633cf680f1246ce649353f813a5a9ca18df0e82aR3-R45): Updated tests to mock the new child components and added new test cases to verify the layout structure and rendering order of the components.

### Addition of new components:

* [`frontend/src/components/popout/PopOut.jsx`](diffhunk://#diff-dd20f2997ff1eb86bc3c58c9b257e8579685c5a8780233210ad855ee85c846ffR1-R21): Added the `PopOut` component, which includes a styled div with text and a button.

### Styling updates:

* [`frontend/src/index.css`](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R1-R23): Integrated Tailwind CSS by importing its base, components, and utilities. Updated the root and body styles to use the default font family and ensure full height and width.